### PR TITLE
build(deps): bump spotbugs-annotations from 4.9.3 to 4.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.9.3</version>
+      <version>4.9.4</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updated the spotbugs-annotations dependency from version 4.9.3 to 4.9.4 to include the latest bug fixes and improvements.

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

Please check the boxes below to confirm that you have followed the
required guidelines for contributions:

- [x] If this pull request includes code changes, they were all properly tested. Automated tests were also included where possible.
- [x] If applicable, this pull request includes the relevant documentation for this change.
- [x] If this pull request is related to an existing issue, you can use the same description below but in any case include a [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) like `Fixes #ISSUE_NUMBER.` or `Closes #ISSUE_NUMBER.`.
- [x] All the commits in this pull request were squashed into a single commit. That commit is [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification).

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Description
Bump spotbugs-annotations from 4.9.3 to 4.9.4.
<!-- prettier-ignore-end -->
